### PR TITLE
Fix error on django 1.9

### DIFF
--- a/django_feedparser/utils.py
+++ b/django_feedparser/utils.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import warnings
 
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from django.core.exceptions import ImproperlyConfigured
 
 class FeedparserError(ImproperlyConfigured):


### PR DESCRIPTION
django.utils.importlib no longer exists
